### PR TITLE
undefined `prompt_tokens` on `openai_token` fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,6 @@ async function run() {
       core.setFailed("`github_token` was not provided");
     }
     const openai = core.getInput("openai_token");
-    console.log(openai);
     const deep = core.getInput("deepinfra_token");
     let type;
     if (!openai && deep) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,7 @@ async function run() {
       core.setFailed("`github_token` was not provided");
     }
     const openai = core.getInput("openai_token");
+    console.log(openai);
     const deep = core.getInput("deepinfra_token");
     let type;
     if (!openai && deep) {
@@ -120,13 +121,10 @@ async function run() {
           );
           let token = "";
           let model = "";
-          console.log("empty");
           if ("openai" === type) {
-            console.log("OPENAI");
             token = openai;
             model = core.getInput("openai_model");
           } else if ("deepinfra" === type) {
-            console.log("DEEP");
             token = deep;
             model = core.getInput("deepinfra_model");
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,9 +75,9 @@ async function run() {
     const openai = core.getInput("openai_token");
     const deep = core.getInput("deepinfra_token");
     let type;
-    if (!openai) {
+    if (!openai && deep) {
       type = "deepinfra";
-    } else if (!deep) {
+    } else if (!deep && openai) {
       type = "openai";
     } else {
       throw new Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,9 +121,11 @@ async function run() {
           let token = "";
           let model = "";
           if ("openai" === type) {
+            console.log("OPENAI");
             token = openai;
             model = core.getInput("openai_model");
           } else if ("deepinfra" === type) {
+            console.log("DEEP");
             token = deep;
             model = core.getInput("deepinfra_model");
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,7 @@ async function run() {
           );
           let token = "";
           let model = "";
+          console.log("empty");
           if ("openai" === type) {
             console.log("OPENAI");
             token = openai;


### PR DESCRIPTION
- deep && openai
- log
- empty log
- log open
- no log


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the logic in `main.ts` to prioritize `deepinfra_token` over `openai`. If `deepinfra_token` is provided, the type will be set to "deepinfra"; otherwise, it defaults to "openai".

### Detailed summary
- Updated logic to prioritize `deepinfra_token` over `openai`
- Set type to "deepinfra" if `deepinfra_token` is provided
- Set type to "openai" if `openai` is provided but not `deepinfra_token`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->