### PR TITLE
fix(#98): generate one suggestion only

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -178,7 +178,7 @@ async function run() {
           await new Feedback(
             new FormattedSummary(
               composed.problems,
-              composed.suggestions
+              composed.suggestion
             ),
             octokit,
             issue,

--- a/src/models.ts
+++ b/src/models.ts
@@ -31,6 +31,7 @@ import {MdSuggestions} from "./prompts/md-suggestions";
 import {Suggestions} from "./prompts/suggestions";
 import {Polish} from "./prompts/polish";
 import {Top} from "./prompts/top";
+import {OneSuggestion} from "./prompts/one-suggestion";
 
 /**
  * Models.
@@ -85,25 +86,34 @@ export class Models {
         ).exec()
       )
     ).exec();
-    const suggestions = await new NamedGoal(
-      "suggestions.md",
+    const suggestion = await new NamedGoal(
+      "one",
       this.def,
       new Default(),
-      new MdSuggestions(
+      new OneSuggestion(
+        problems,
         await new NamedGoal(
-          "suggestions",
+          "suggestions.md",
           this.def,
           new Default(),
-          new Suggestions(
-            report,
-            problems
+          new MdSuggestions(
+            await new NamedGoal(
+              "suggestions",
+              this.def,
+              new Default(),
+              new Suggestions(
+                report,
+                problems
+              )
+            ).exec()
           )
-        ).exec()
+        ).exec(),
+        report
       )
     ).exec();
     return {
       problems: problems,
-      suggestions: suggestions
+      suggestion: suggestion
     }
   }
 }

--- a/src/prompts/one-suggestion.ts
+++ b/src/prompts/one-suggestion.ts
@@ -23,28 +23,39 @@
  */
 
 /**
- * Formatted summary, from JSON objects into GitHub Markdown.
+ * One suggestion.
  */
-export class FormattedSummary implements Scalar<string> {
+export class OneSuggestion implements Scalar<string> {
 
   /**
    * Ctor.
-   * @param problems Problems
+   * @param probmels Problems
    * @param suggestions Suggestions
+   * @param report Report
    */
   constructor(
-    private readonly problems: any,
-    private readonly suggestions: any
+    private readonly probmels: any,
+    private readonly suggestions: any,
+    private readonly report: string
   ) {
   }
 
   value(): string {
     return `
-    ### Problems
-${this.problems}
-
-    ### Suggestion
+    Take a look at suggestions we propose for solving outlined problems with quality
+    of following bug report. Such long list of suggestions is absolutely useless.
+    Nobody reads it and nobody pays attention. In order to be useful,
+    please suggest only one specific improvement to be made.
+    The suggestion must be short, less than 30 words.
+    
+    Suggestions:
 ${this.suggestions}
-    `;
+
+    Problems:
+${this.probmels}
+
+    Report:
+${this.report}
+    `
   }
 }

--- a/tests/formatted-summary.test.ts
+++ b/tests/formatted-summary.test.ts
@@ -22,29 +22,24 @@
  * SOFTWARE.
  */
 
+import {FormattedSummary} from "../src/formatted-summary";
+
 /**
- * Formatted summary, from JSON objects into GitHub Markdown.
+ * Test cases for FormattedSummary.
  */
-export class FormattedSummary implements Scalar<string> {
-
-  /**
-   * Ctor.
-   * @param problems Problems
-   * @param suggestion Suggestion
-   */
-  constructor(
-    private readonly problems: any,
-    private readonly suggestion: any
-  ) {
-  }
-
-  value(): string {
-    return `
+describe('Test cases for FormattedSummary', () => {
+  test("returns formatted summary", () => {
+    const problems = "some problems";
+    const suggestion = "some suggestion";
+    const fmt = new FormattedSummary(problems, suggestion).value();
+    expect(fmt).toBe(
+`
     ### Problems
-${this.problems}
+${problems}
 
     ### Suggestion
-${this.suggestion}
-    `;
-  }
-}
+${suggestion}
+    `
+    )
+  });
+});


### PR DESCRIPTION
ref #98

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the codebase to use a singular "suggestion" instead of "suggestions" for clarity and consistency.

### Detailed summary
- Refactored `FormattedSummary` to use `suggestion` instead of `suggestions`
- Updated `Models` to use `suggestion` instead of `suggestions`
- Added `OneSuggestion` class for a single suggestion in prompts
- Updated tests for `FormattedSummary` and `OneSuggestion`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->